### PR TITLE
rewrite split mode

### DIFF
--- a/draft-kazuho-quic-authenticated-handshake.md
+++ b/draft-kazuho-quic-authenticated-handshake.md
@@ -348,7 +348,6 @@ the hidden server, in addition to those required by the Encrypted SNI
 extension:
 
 * hmac_key
-* spare Connection IDs
 * ODCID
 
 Both the fronting server and the hidden server need access to the hmac_key to
@@ -356,15 +355,25 @@ authenticate the Initial packets.  However, because the key is derived from
 the shared DH secret of ESNI, it is not necessarily available to the hidden
 server.
 
-Access to spare Connection IDs is mandatory to support clients migrating to
-different addresses.  The fronting server, without access to the 1-RTT QUIC
-frames being exchanged, cannot track the mapping of the Connection IDs that
-change mid-connection.
-
 ODCID is necessary to decrypt an Initial packet sent in response to a Retry.
 However, the value is typically available only to the server that generates
 the Retry.  The fronting server and the hidden server need to exchange the
 ODCID, or provide the secret for extracting the ODCID from a Retry token.
+
+Additionally, the following properties need to be exchanged when providing
+support for connection migration:
+
+* client's address tuple
+* spare Connection IDs
+
+The fronting server needs to forward the source IP address and port of the
+incoming packets to the hidden server, so that the hidden server can recognize
+the migration of the client and respond as required by QUIC version 1.
+
+The fronting server and the hidden server also need to share the spare
+Connection IDs being issued to the client using NEW_CONNECTION_ID frames, so
+that the fronting server can continue forwarding packets to the correct hidden
+server when the client starts using a new connection ID mid-connection.
 
 # Security Considerations
 

--- a/draft-kazuho-quic-authenticated-handshake.md
+++ b/draft-kazuho-quic-authenticated-handshake.md
@@ -318,26 +318,25 @@ packet means that the retransmitted Initial packets would become undecryptable
 and therefore be deemed lost by the client, reducing the client's congestion
 window size.
 
-## No Support for Split Mode
+## Split Mode
 
-Under the design discussed in this document, it is impossible to use an
-unmodified QUIC server as a backend server in "Split Mode" ([TLS-ESNI];
-section 3) due to the following two reasons:
+To support server-side deployments using "Split Mode" ([TLS-ESNI]; section 3),
+the following properties need to be exchanged between the fronting server and
+the hidden server, in addition to those required by the Encrypted SNI
+extension:
 
-* Access to initial_auth_secret is required for generating and validating
-  Initial packets.  However, the backend server, not knowing the ESNI private
-  key, cannot calculate the secret.
+* hmac_key
+* spare Connection IDs
 
-* The client-facing server cannot continue forwarding packets to the correct
-  destination when there is a change in Connection ID mid-connection.
+Both the fronting server and the hidden server need access to the hmac_key to
+authenticate the Initial packets.  However, because the key is derived from
+the shared DH secret of ESNI, it is not necessarily available to the hidden
+server.
 
-To address the issues, we might consider specifying a protocol that will be
-used between the client-facing server and the backend server for communicating
-the initial_auth_secret and the spare Connection IDs.  Note that such protocol
-can be lightweight, assuming the communication between the two servers will be
-over a virtual private network.  Such assumption can be made because the
-backend server cannot operate QUIC without access to the source address-port
-tuple of the packets that the client has sent.
+Access to spare Connection IDs is mandatory to support clients migrating to
+different addresses.  The fronting server, without access to the 1-RTT QUIC
+frames being exchanged, cannot track the mapping of the Connection IDs that
+change mid-connection.
 
 # Security Considerations
 

--- a/draft-kazuho-quic-authenticated-handshake.md
+++ b/draft-kazuho-quic-authenticated-handshake.md
@@ -349,6 +349,7 @@ extension:
 
 * hmac_key
 * spare Connection IDs
+* ODCID
 
 Both the fronting server and the hidden server need access to the hmac_key to
 authenticate the Initial packets.  However, because the key is derived from
@@ -359,6 +360,11 @@ Access to spare Connection IDs is mandatory to support clients migrating to
 different addresses.  The fronting server, without access to the 1-RTT QUIC
 frames being exchanged, cannot track the mapping of the Connection IDs that
 change mid-connection.
+
+ODCID is necessary to decrypt an Initial packet sent in response to a Retry.
+However, the value is typically available only to the server that generates
+the Retry.  The fronting server and the hidden server need to exchange the
+ODCID, or provide the secret for extracting the ODCID from a Retry token.
 
 # Security Considerations
 

--- a/draft-kazuho-quic-authenticated-handshake.md
+++ b/draft-kazuho-quic-authenticated-handshake.md
@@ -344,8 +344,8 @@ window size.
 
 To support server-side deployments using "Split Mode" ([TLS-ESNI]; section 3),
 the following properties need to be exchanged between the fronting server and
-the hidden server, in addition to those required by the Encrypted SNI
-extension:
+the hidden server, in addition to those generally required by a QUIC version 1
+proxy and the Encrypted SNI extension:
 
 * hmac_key
 * ODCID
@@ -359,21 +359,6 @@ ODCID is necessary to decrypt an Initial packet sent in response to a Retry.
 However, the value is typically available only to the server that generates
 the Retry.  The fronting server and the hidden server need to exchange the
 ODCID, or provide the secret for extracting the ODCID from a Retry token.
-
-Additionally, the following properties need to be exchanged when providing
-support for connection migration:
-
-* client's address tuple
-* spare Connection IDs
-
-The fronting server needs to forward the source IP address and port of the
-incoming packets to the hidden server, so that the hidden server can recognize
-the migration of the client and respond as required by QUIC version 1.
-
-The fronting server and the hidden server also need to share the spare
-Connection IDs being issued to the client using NEW_CONNECTION_ID frames, so
-that the fronting server can continue forwarding packets to the correct hidden
-server when the client starts using a new connection ID mid-connection.
 
 # Security Considerations
 


### PR DESCRIPTION
Current text implies that support for Split Mode in QUIC-AH is substantially complicated compared to doing that in TLS-ESNI.

But actually, draft-tls-esni-02 already requires coordination between the fronting server and the hidden server. QUIC-AH is just adding some properties to the coordination.

The updated text clarifies that.