### PR TITLE
Update ref to tls-esi-03, add "robustness" support

### DIFF
--- a/draft-kazuho-quic-authenticated-handshake.md
+++ b/draft-kazuho-quic-authenticated-handshake.md
@@ -62,8 +62,8 @@ normative:
   TLS-ESNI:
     title: Encrypted Server Name Indication for TLS 1.3
     seriesinfo:
-      Internet-Draft: draft-ietf-tls-esni-02
-    date: 2018-10-22
+      Internet-Draft: draft-ietf-tls-esni-03
+    date: 2019-03-11
     author:
       -
         ins: E. Rescorla
@@ -200,9 +200,31 @@ fails.
 
 ## Version Negotiation Packet
 
-A client MUST ignore Version Negotiation packets.  When the client gives up of
-establishing a connection, it MAY report the failure differently based on the
-receipt of (or lack of) Version Negotiation packets.
+A server sends a Version Negotiation packet when receiving a long header packet
+carrying a version number that it does not recognize.  This can happen when the
+ESNI Resource Records used by the endpoints become out of sync, or when the
+server stops using the authenticated handshake.
+
+Because such case is exceptional, a client SHOULD NOT respond immediately to a
+Version Negotiation packet.  Instead, it SHOULD buffer the Version Negotiation
+packet that it has received, continue the handshake as if it has not received
+it.
+
+After the client is confident that the server is not responding using the QUIC
+version that the client has offered, it SHOULD process the Version Negotiation
+packet and fall back to the most preferred version specified by the Version
+Negotiation packet.
+
+The TLS handshake message transmitted using the fallback version MUST contain
+a "server_name" extension carrying the public name specified by the ESNI
+Resource Record, along with an empty "encrypted_server_name" extension.  This
+allows the server to provide, through an authenicated channel, either the
+correct ESNI Resource Record or the lack of support for Encrypted SNI and
+authenticated handshake (see {{TLS-ESNI}}; section 5.1.2).
+
+The client then reattempts to establish a connection, either by using the newly
+provided ESNI Resource Record (if any), or by using the fallback version without
+using the "encrypted_server_name" extension.
 
 ## Connection Close Packet
 

--- a/draft-kazuho-quic-authenticated-handshake.md
+++ b/draft-kazuho-quic-authenticated-handshake.md
@@ -201,9 +201,12 @@ fails.
 ## Version Negotiation Packet
 
 A server sends a Version Negotiation packet when receiving a long header packet
-carrying a version number that it does not recognize.  This can happen when the
-ESNI Resource Records used by the endpoints become out of sync, or when the
-server stops using the authenticated handshake.
+carrying a version number that it does not recognize.  In addition, a server
+SHOULD send a Version Negotiation packet when it recognizes the version as being
+one used by the authenticated handshake, but when it fails to authenticate the
+Initial packets.  These happen when the ESNI Resource Records used by the
+endpoints become out of sync, or when the server stops using the authenticated
+handshake.
 
 Because such case is exceptional, a client SHOULD NOT respond immediately to a
 Version Negotiation packet.  Instead, it SHOULD buffer the Version Negotiation


### PR DESCRIPTION
Now that https://github.com/tlswg/draft-ietf-tls-esni/pull/124 has been merged, QUIC-AH needs to provide a way to correct the ESNI Resource Record when the record possessed by the endpoints become out-of-sync.

This PR describes the fallback mechanism. In short, it works like follows:
1. Client sends QUIC-AH Initial packet.
2. A server failing to process the Initial sends VN specifying v1.
3. Client sends V1 Initial containing CH with empty "encrypted_server_name" extension.
4. Server either sends the ESNI record, or the lack of, in the way specified by ESNI.
5. Client reattempts to create a connection.

The thing here is that we essentially need a non-authenticated ESNI handshake for obtaining the correct ESNI key (see step 3). At the moment, step 3 uses an empty "encrypted_server_name" extension because the purpose here is to purely obtain the correct ESNI record (or the lack of), but we can send an ordinary ESNI extension here too.

Then, the question that become apparent is: should we define a mechanism to just run ESNI+version greasing (#13), and make "authenticated handshake" an optional feature?